### PR TITLE
Add GitHub PR checks for reminder validation

### DIFF
--- a/Annoy-o-Bot/CallbackHandler.cs
+++ b/Annoy-o-Bot/CallbackHandler.cs
@@ -110,6 +110,13 @@ namespace Annoy_o_Bot
                 
             }
 
+            await installationClient.Check.Run.Create(requestObject.Repository.Id,
+                new NewCheckRun("annoy-o-bot", requestObject.HeadCommit.Id)
+                {
+                    Status = CheckStatus.Completed,
+                    Conclusion = CheckConclusion.Success
+                });
+
             return new OkResult();
 
             string BuildDocumentId(string fileName)

--- a/Annoy-o-Bot/CallbackHandler.cs
+++ b/Annoy-o-Bot/CallbackHandler.cs
@@ -118,8 +118,10 @@ namespace Annoy_o_Bot
                     continue;
                 }
 
-                var content =
-                    await installationClient.Repository.Content.GetAllContents(requestObject.Repository.Id, newFile);
+                var content = await installationClient.Repository.Content.GetAllContentsByRef(
+                    requestObject.Repository.Id, 
+                    newFile, 
+                    requestObject.Ref);
                 var reminder = reminderParser.Parse(content.First().Content);
                 results.Add((newFile, reminder));
             }


### PR DESCRIPTION
closes #3 

Parse reminders on non-default-branches and save checks about the parse status to provide status checks on PRs.

The status checks should only appear on PRs that are related to reminders.
Does not support to manually re-run checks as the `check_run`/`check_suite` events are ignored.