### PR TITLE
Merge commits

### DIFF
--- a/Annoy-o-Bot.Tests/CommitParserTests.cs
+++ b/Annoy-o-Bot.Tests/CommitParserTests.cs
@@ -5,39 +5,6 @@ namespace Annoy_o_Bot.Tests
     public class CommitParserTests
     {
         [Fact]
-        public void When_merge_commit_should_only_return_reminders_from_merge_commit()
-        {
-            // forward integrate brings in reminder history that is already on the target branch and therefore not present on the actual merge commit
-            var commitModel = new[]
-            {
-                new CallbackModel.CommitModel
-                {
-                    Message = "Add new reminder",
-                    Added = new []{ ".reminders/new-reminder" }
-                }, 
-                new CallbackModel.CommitModel
-                {
-                    Message = "Forward integrate",
-                    Removed = new []{ ".reminders/deleted-reminder" },
-                    Modified = new []{ ".reminders/modified-reminder" },
-                    Added = new []{ ".reminders/added-reminder" }
-                }, 
-                new CallbackModel.CommitModel
-                {
-                    Message = "Merge branch 'sample-branch'",
-                    Removed = new string[0],
-                    Added = new []{ ".reminders/new-reminder" }
-                }
-            };
-
-            var deletedReminders = CommitParser.GetDeletedReminders(commitModel);
-            Assert.Empty(deletedReminders);
-
-            var newReminders = CommitParser.GetReminders(commitModel);
-            Assert.Equal(".reminders/new-reminder", Assert.Single(newReminders));
-        }
-
-        [Fact]
         public void GetDeletedReminders_should_only_return_deleted_files_in_reminder_folder()
         {
             var commitModel = new[]

--- a/Annoy-o-Bot.Tests/CommitParserTests.cs
+++ b/Annoy-o-Bot.Tests/CommitParserTests.cs
@@ -5,9 +5,8 @@ namespace Annoy_o_Bot.Tests
     public class CommitParserTests
     {
         [Fact]
-        public void GetDeletedReminders_should_only_return_deleted_json_files_in_reminder_folder()
+        public void GetDeletedReminders_should_only_return_deleted_files_in_reminder_folder()
         {
-            var parser = new CommitParser();
             var commitModel = new[]
             {
 
@@ -35,7 +34,6 @@ namespace Annoy_o_Bot.Tests
         [Fact]
         public void GetDeletedReminders_should_return_removed_files_from_all_commits()
         {
-            var parser = new CommitParser();
             var commitModel = new[]
             {
 
@@ -75,7 +73,6 @@ namespace Annoy_o_Bot.Tests
         [Fact]
         public void GetDeletedReminders_should_not_return_reverted_removed_files()
         {
-            var parser = new CommitParser();
             var commitModel = new[]
             {
 
@@ -103,7 +100,6 @@ namespace Annoy_o_Bot.Tests
         [Fact]
         public void GetDeletedReminders_return_removed_files_with_complex_history()
         {
-            var parser = new CommitParser();
             var commitModel = new[]
             {
 
@@ -139,7 +135,6 @@ namespace Annoy_o_Bot.Tests
         [Fact]
         public void GetDeletedReminders_should_return_removed_modified_files()
         {
-            var parser = new CommitParser();
             var commitModel = new[]
             {
 
@@ -168,7 +163,6 @@ namespace Annoy_o_Bot.Tests
         [Fact]
         public void GetDeletedReminders_should_not_return_reverted_reminders()
         {
-            var parser = new CommitParser();
             var commitModel = new[]
             {
 
@@ -194,9 +188,8 @@ namespace Annoy_o_Bot.Tests
         }
 
         [Fact]
-        public void GetReminders_Should_only_return_json_files_in_reminder_folder()
+        public void GetReminders_Should_only_return_files_in_reminder_folder()
         {
-            var parser = new CommitParser();
             var commitModel = new[]
             {
 
@@ -225,7 +218,6 @@ namespace Annoy_o_Bot.Tests
         [Fact]
         public void GetReminders_Should_return_added_files_from_all_commits()
         {
-            var parser = new CommitParser();
             var commitModel = new[]
             {
 
@@ -265,7 +257,6 @@ namespace Annoy_o_Bot.Tests
         [Fact]
         public void GetReminders_Should_not_return_reverted_new_files()
         {
-            var parser = new CommitParser();
             var commitModel = new[]
             {
 
@@ -293,7 +284,6 @@ namespace Annoy_o_Bot.Tests
         [Fact]
         public void GetReminders_Should_not_return_deleted_modified_files()
         {
-            var parser = new CommitParser();
             var commitModel = new[]
             {
 
@@ -321,7 +311,6 @@ namespace Annoy_o_Bot.Tests
         [Fact]
         public void GetReminders_Should_return_added_reverted_added_again_file()
         {
-            var parser = new CommitParser();
             var commitModel = new[]
             {
 
@@ -357,7 +346,6 @@ namespace Annoy_o_Bot.Tests
         [Fact]
         public void GetReminders_should_include_modified_reminders()
         {
-            var parser = new CommitParser();
             var commitModel = new[]
             {
 

--- a/Annoy-o-Bot.Tests/CommitParserTests.cs
+++ b/Annoy-o-Bot.Tests/CommitParserTests.cs
@@ -5,6 +5,39 @@ namespace Annoy_o_Bot.Tests
     public class CommitParserTests
     {
         [Fact]
+        public void When_merge_commit_should_only_return_reminders_from_merge_commit()
+        {
+            // forward integrate brings in reminder history that is already on the target branch and therefore not present on the actual merge commit
+            var commitModel = new[]
+            {
+                new CallbackModel.CommitModel
+                {
+                    Message = "Add new reminder",
+                    Added = new []{ ".reminders/new-reminder" }
+                }, 
+                new CallbackModel.CommitModel
+                {
+                    Message = "Forward integrate",
+                    Removed = new []{ ".reminders/deleted-reminder" },
+                    Modified = new []{ ".reminders/modified-reminder" },
+                    Added = new []{ ".reminders/added-reminder" }
+                }, 
+                new CallbackModel.CommitModel
+                {
+                    Message = "Merge branch 'sample-branch'",
+                    Removed = new string[0],
+                    Added = new []{ ".reminders/new-reminder" }
+                }
+            };
+
+            var deletedReminders = CommitParser.GetDeletedReminders(commitModel);
+            Assert.Empty(deletedReminders);
+
+            var newReminders = CommitParser.GetReminders(commitModel);
+            Assert.Equal(".reminders/new-reminder", Assert.Single(newReminders));
+        }
+
+        [Fact]
         public void GetDeletedReminders_should_only_return_deleted_files_in_reminder_folder()
         {
             var commitModel = new[]

--- a/Annoy-o-Bot.Tests/CommitParserTests.cs
+++ b/Annoy-o-Bot.Tests/CommitParserTests.cs
@@ -418,5 +418,12 @@ namespace Annoy_o_Bot.Tests
                 ".reminders/existingReminder2.json"
             }, result);
         }
+
+        [Fact]
+        public void Should_return_no_results_when_no_commits()
+        {
+            Assert.Empty(CommitParser.GetReminders(new CallbackModel.CommitModel[0]));
+            Assert.Empty(CommitParser.GetDeletedReminders(new CallbackModel.CommitModel[0]));
+        }
     }
 }

--- a/Annoy-o-Bot.Tests/RequestParserTests.cs
+++ b/Annoy-o-Bot.Tests/RequestParserTests.cs
@@ -21,6 +21,7 @@ namespace Annoy_o_Bot.Tests
             Assert.Equal("ba7c6f17f5beaafc603eca52b864356848865fec", commit.Id);
             var addedFile = Assert.Single(commit.Added);
             Assert.Equal(".reminder/testReminder.json", addedFile);
+            Assert.Equal("Create trigger4.json", commit.Message);
 
             Assert.Equal("timbussmann", result.Pusher.Name);
             
@@ -36,18 +37,22 @@ namespace Annoy_o_Bot.Tests
             Assert.Equal(".reminder/newFile.json", Assert.Single(result.Commits[0].Added));
             Assert.Empty(result.Commits[0].Modified);
             Assert.Empty(result.Commits[0].Removed);
+            Assert.Equal("Create newFile.json", result.Commits[0].Message);
 
             Assert.Equal(".reminder/newFile.json", Assert.Single(result.Commits[1].Modified));
             Assert.Empty(result.Commits[1].Added);
             Assert.Empty(result.Commits[1].Removed);
+            Assert.Equal("Update newFile.json", result.Commits[1].Message);
 
             Assert.Equal(".reminder/newFile.json", Assert.Single(result.Commits[2].Removed));
             Assert.Empty(result.Commits[2].Added);
             Assert.Empty(result.Commits[2].Modified);
+            Assert.Equal("Delete newFile.json", result.Commits[2].Message);
 
             Assert.Empty(result.Commits[3].Added);
             Assert.Empty(result.Commits[3].Modified);
             Assert.Empty(result.Commits[3].Removed);
+            Assert.Equal("Merge pull request #15 from timbussmann/file-ops-history\n\nCreate newFile.json", result.Commits[3].Message);
 
             Assert.Equal("cb1ec97f51657c2718ab4e0b1d0bf2656aeb3127", result.HeadCommit.Id);
         }

--- a/Annoy-o-Bot/CallbackModel.cs
+++ b/Annoy-o-Bot/CallbackModel.cs
@@ -17,6 +17,7 @@ namespace Annoy_o_Bot
         public class CommitModel
         {
             public string Id { get; set; }
+            public string Message { get; set; }
             public string[] Added { get; set; } = new string[0];
             public string[] Modified { get; set; } = new string[0];
             public string[] Removed { get; set; } = new string[0];

--- a/Annoy-o-Bot/CommitParser.cs
+++ b/Annoy-o-Bot/CommitParser.cs
@@ -7,8 +7,6 @@ namespace Annoy_o_Bot
     {
         public static string[] GetReminders(CallbackModel.CommitModel[] commits)
         {
-            commits = SelectRelevantCommits(commits);
-
             return commits.Aggregate(new HashSet<string>(), (added, commit) =>
             {
                 foreach (var newFile in commit.Added)
@@ -34,8 +32,6 @@ namespace Annoy_o_Bot
 
         public static string[] GetDeletedReminders(CallbackModel.CommitModel[] commits)
         {
-            commits = SelectRelevantCommits(commits);
-
             return commits.Aggregate((removed: new HashSet<string>(), @new: new HashSet<string>()), (tuple, commit) =>
                 {
                     foreach (var newFile in commit.Added)
@@ -64,18 +60,6 @@ namespace Annoy_o_Bot
                 .Where(x => x.StartsWith(".reminders/"))
                 .ToArray();
 
-        }
-
-        private static CallbackModel.CommitModel[] SelectRelevantCommits(CallbackModel.CommitModel[] commits)
-        {
-            // if the last commit is a merge commit, ignore other commits as the merge commits contains all the relevant changes
-            // TODO: This behavior will be incorrect if a non-merge-commit contains this commit message. To be absolutely sure, we'd have to retrieve the full commit object and inspect the parent information. This information is not available on the callback object
-            if (commits.LastOrDefault()?.Message?.StartsWith("Merge ") ?? false)
-            {
-                commits = commits.TakeLast(1).ToArray();
-            }
-
-            return commits;
         }
     }
 }

--- a/Annoy-o-Bot/CommitParser.cs
+++ b/Annoy-o-Bot/CommitParser.cs
@@ -7,19 +7,19 @@ namespace Annoy_o_Bot
     {
         public static string[] GetReminders(CallbackModel.CommitModel[] commits)
         {
-            return commits.Aggregate(new HashSet<string>(), (added, model) =>
+            return commits.Aggregate(new HashSet<string>(), (added, commit) =>
             {
-                foreach (var newFile in model.Added)
+                foreach (var newFile in commit.Added)
                 {
                     added.Add(newFile);
                 }
 
-                foreach (var modifiedFile in model.Modified)
+                foreach (var modifiedFile in commit.Modified)
                 {
                     added.Add(modifiedFile);
                 }
 
-                foreach (var remvovedFile in model.Removed)
+                foreach (var remvovedFile in commit.Removed)
                 {
                     added.Remove(remvovedFile);
                 }
@@ -32,9 +32,9 @@ namespace Annoy_o_Bot
 
         public static string[] GetDeletedReminders(CallbackModel.CommitModel[] commits)
         {
-            return commits.Aggregate((removed: new HashSet<string>(), @new: new HashSet<string>()), (tuple, model) =>
+            return commits.Aggregate((removed: new HashSet<string>(), @new: new HashSet<string>()), (tuple, commit) =>
                 {
-                    foreach (var newFile in model.Added)
+                    foreach (var newFile in commit.Added)
                     {
                         if (tuple.removed.Contains(newFile))
                         {
@@ -46,7 +46,7 @@ namespace Annoy_o_Bot
                         }
                     }
 
-                    foreach (var remvovedFile in model.Removed)
+                    foreach (var remvovedFile in commit.Removed)
                     {
                         if (!tuple.@new.Contains(remvovedFile))
                         {


### PR DESCRIPTION
Fixes #5 

Ignore all other files in commits that are listed as part of a merge commit as the merge commit contains the relevant files for the main branch. For dry-runs (checks), all commits are continued to be used.