### PR TITLE
Add callback verification check

### DIFF
--- a/Annoy-o-Bot/CallbackHandler.cs
+++ b/Annoy-o-Bot/CallbackHandler.cs
@@ -26,6 +26,7 @@ namespace Annoy_o_Bot
             [CosmosDB(dbName, collectionId, ConnectionStringSetting = "CosmosDBConnection")]IDocumentClient documentClient,
             ILogger log)
         {
+            GitHubHelper.ValidateRequest(req);
             if (!req.Headers.TryGetValue("X-GitHub-Event", out var callbackEvent) || callbackEvent != "push")
             {
                 // this typically seem to be installation related events.


### PR DESCRIPTION
verifies the incoming webhook to originate from github to prevent malicious requests from being handled.

Todo:
* [x] Generate secret token in the app
* [x] Deploy token to Azure