### PR TITLE
Prevent only-once reminders from being queried infinitely

### DIFF
--- a/Annoy-o-Bot.Tests/TimeoutFunctionTests.cs
+++ b/Annoy-o-Bot.Tests/TimeoutFunctionTests.cs
@@ -82,24 +82,24 @@ namespace Annoy_o_Bot.Tests
         }
 
         [Theory]
-        [InlineData("2020.01.01", 1, "2020.01.01")]
-        [InlineData("2020.01.01", 2, "2020.01.01")]
-        [InlineData("2020.01.01", 5, "2020.01.01")]
-        [InlineData("2019.12.24", 1, "2019.12.24")]
+        [InlineData("2020.01.01", 1, null)]
+        [InlineData("2020.01.01", 2, null)]
+        [InlineData("2020.01.01", 5, null)]
+        [InlineData("2019.12.24", 1, null)]
         public void Should_not_calculate_next_reminder_date_once(string nextReminder, int? intervalStep,
             string expectedResult)
         {
             var result = CalculateReminder(Interval.Once, nextReminder, intervalStep);
 
-            Assert.Equal(DateTime.Parse(expectedResult), result);
+            Assert.Equal(expectedResult, result?.ToString("yyyy.MM.dd"));
         }
 
-        static DateTime CalculateReminder(Interval interval, string nextReminder, int? intervalStep)
+        static DateTime? CalculateReminder(Interval interval, string nextReminder, int? intervalStep)
         {
             var reminder = new ReminderDocument
             {
                 NextReminder = DateTime.Parse(nextReminder),
-                Reminder = new Reminder()
+                Reminder = new Reminder
                 {
                     Interval = interval,
                     IntervalStep = intervalStep

--- a/Annoy-o-Bot/Storage/ReminderDocument.cs
+++ b/Annoy-o-Bot/Storage/ReminderDocument.cs
@@ -12,7 +12,7 @@ namespace Annoy_o_Bot
         public long InstallationId { get; set; }
         public long RepositoryId { get; set; }
         public DateTime LastReminder { get; set; }
-        public DateTime NextReminder { get; set; }
+        public DateTime? NextReminder { get; set; }
         public string Path { get; set; } = null!;
 
         public void CalculateNextReminder(DateTime now)
@@ -23,6 +23,7 @@ namespace Annoy_o_Bot
                 switch (Reminder.Interval)
                 {
                     case Interval.Once:
+                        NextReminder = null;
                         break;
                     case Interval.Daily:
                         NextReminder = GetNextReminderDate(x => x.AddDays(intervalSteps));
@@ -43,7 +44,7 @@ namespace Annoy_o_Bot
 
             DateTime GetNextReminderDate(Func<DateTime, DateTime> incrementFunc)
             {
-                var next = NextReminder;
+                var next = NextReminder!.Value;
                 while (next <= now)
                 {
                     next = incrementFunc(next);


### PR DESCRIPTION
Because the `NextReminder` date wasn't updated on reminders executed with `Once`, the query would always find such reminders again. This would generate warning log entries and attempt to re-calculate the next execution date (which wouldn't change).

This PR removes the `NextReminder` date once it has been executed once which will prevent it from being detected again. 

Alternatively, the date could be set to `DateTime.MaxValue` which would also effectively prevent it from being ever queried again but might be less clear about the intention. The reminder could also be completely removed, which might cause problems in case the reminder is updated at a later point for some reason though.