### PR TITLE
Don't reuse/share hash instances

### DIFF
--- a/Annoy-o-Bot.Tests/GitHubHelperTests.cs
+++ b/Annoy-o-Bot.Tests/GitHubHelperTests.cs
@@ -11,16 +11,15 @@
     public class GitHubHelperTests
     {
         [Theory]
-        [InlineData("B0D3E5FBD7B71A4539E27257AF48C677E8CAD2F803C2CC87C3164CD4254AFF79")]
-        [InlineData("b0d3e5fbd7b71a4539e27257af48c677e8cad2f803c2cc87c3164cd4254aff79")]
+        [InlineData("46F335537C051512C7554148D3683D98DEE8843E2E919A21065E0BD5FD09CDA5")]
+        [InlineData("46f335537c051512c7554148d3683d98dee8843e2e919a21065e0bd5fd09cda5")]
         public void Should_verify_valid_body(string hash)
         {
             var request = new DefaultHttpRequest(new DefaultHttpContext());
             request.Headers.Add("X-Hub-Signature-256", $"sha256={hash}");
             request.Body = new MemoryStream(Encoding.UTF8.GetBytes("Hello World!"));
             
-            var hmac = new HMACSHA256(new byte[]{ 1, 3, 4, 8, 7, 2, 6});
-            GitHubHelper.ValidateRequest(request, hmac, null);
+            GitHubHelper.ValidateRequest(request, "secretkey", null);
         }
 
         [Fact]
@@ -30,8 +29,7 @@
             request.Headers.Add("X-Hub-Signature-256", "sha256=B0D3E5FBD7B71A4539E27257AF48C677E8CAD2F803C2CC87C3164CD4254AFF79");
             request.Body = new MemoryStream(Encoding.UTF8.GetBytes("Hello Wörld!"));
             
-            var hmac = new HMACSHA256(new byte[] { 1, 3, 4, 8, 7, 2, 6 });
-            Assert.Throws<Exception>(() => GitHubHelper.ValidateRequest(request, hmac, null));
+            Assert.Throws<Exception>(() => GitHubHelper.ValidateRequest(request, "somekey", null));
         }
     }
 }

--- a/Annoy-o-Bot/CallbackHandler.cs
+++ b/Annoy-o-Bot/CallbackHandler.cs
@@ -16,6 +16,8 @@ namespace Annoy_o_Bot
 {
     public static class CallbackHandler
     {
+        static string? callbackSecret = Environment.GetEnvironmentVariable("WebhookSecret");
+
         internal const string dbName = "annoydb";
         internal const string collectionId = "reminders";
 
@@ -26,7 +28,7 @@ namespace Annoy_o_Bot
             [CosmosDB(dbName, collectionId, ConnectionStringSetting = "CosmosDBConnection")]IDocumentClient documentClient,
             ILogger log)
         {
-            GitHubHelper.ValidateRequest(req, GitHubHelper.SHA256, log);
+            GitHubHelper.ValidateRequest(req, callbackSecret ?? throw new Exception("Missing 'WebhookSecret' env var"), log);
             if (!req.Headers.TryGetValue("X-GitHub-Event", out var callbackEvent) || callbackEvent != "push")
             {
                 if (callbackEvent != "check_suite") // ignore check_suite events


### PR DESCRIPTION
The classes don't seem to be threadsafe, so concurrent requests might cause issues with the signature validation.